### PR TITLE
Address unset environment variable defaults

### DIFF
--- a/utils/globalData.js
+++ b/utils/globalData.js
@@ -1,8 +1,12 @@
 export const getGlobalData = () => {
+
+  const name = process.env.BLOG_NAME ? decodeURI(process.env.BLOG_NAME) : "Jay Doe";
+  const blogTitle = process.env.BLOG_TITLE ? decodeURI(process.env.BLOG_TITLE) : "Next.js Blog Theme";
+  const footerText = process.env.BLOG_FOOTER_TEXT ? decodeURI(process.env.BLOG_FOOTER_TEXT) : "All rights reserved.";
+
   return {
-    name: decodeURI(process.env.BLOG_NAME) || "Jay Doe",
-    blogTitle: decodeURI(process.env.BLOG_TITLE) || "Next.js Blog Theme",
-    footerText:
-      decodeURI(process.env.BLOG_FOOTER_TEXT) || "All rights reserved.",
+    name,
+    blogTitle,
+    footerText
   };
 };


### PR DESCRIPTION
## Summary

The previous operation of `decodeURI(process.env.VAR_NAME)` would lead to the output of `"undefined"` if that environment variable was not set already. To use our defaults, instead of using the pipe operator, I chose to use the ternary operator where we verify the existence first and then proceed with the operation.

### Visual difference

| Before  | After |
| :---: | :---: |
| ![Website with the author "undefined" and blog title "undefined"](https://user-images.githubusercontent.com/8431042/150388313-a7891229-2d5a-40a2-854f-a8e2ad932177.png) | ![Website with the author "Jay Doe" and blog title "Next.js Blog Theme"](https://user-images.githubusercontent.com/8431042/150387899-c546f4b3-f808-4d5f-b2bd-912d3acf9879.png) | 

### Testing Plan

#### No environment variables set
- Checkout the branch locally
- Run the server
- Open the browser and navigate to <http://localhost:3000>
- Verify that the blog author, title, footer defaults are there "Jay Doe", "Next.js Blog Theme", "All rights reserved."
---

#### With environment variables set
- Stop the server
- Set the environment variables to what ever values you'd like (env variables include `BLOG_NAME`, `BLOG_TITLE`, and `BLOG_FOOTER_TEXT`
- Run the server
- Open the browser and navigate to <http://localhost:3000>
- Verify that the blog author, title, footer matches to what you set
