### PR TITLE
Refactor code around dark/light theme

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -54,7 +54,8 @@ const ThemeSwitcher = () => {
         type="button"
         aria-label="Use Dark Mode"
         onClick={() => {
-          window.__setPreferredTheme("dark");
+          document.documentElement.classList.add("dark");
+          localStorage.setItem("theme", "dark");
         }}
         className="flex items-center h-full pr-2 dark:bg-primary rounded-3xl flex justify-center align-center p-2 w-24 h-10 transition"
       >
@@ -65,7 +66,8 @@ const ThemeSwitcher = () => {
         type="button"
         aria-label="Use Light Mode"
         onClick={() => {
-          window.__setPreferredTheme("light");
+          document.documentElement.classList.remove("dark");
+          localStorage.setItem("theme", "light");
         }}
         className="flex items-center h-full pr-2 bg-primary dark:bg-transparent rounded-3xl flex justify-center align-center p-2 w-24 h-10 transition"
       >

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import React, { useEffect } from "react";
 import styles from "./Layout.module.css";
 
 export function GradientBackground({ variant, className }) {
@@ -13,7 +14,46 @@ export function GradientBackground({ variant, className }) {
   return <div className={classes} />;
 }
 
+export const ThemeContext = React.createContext("light");
+
 export default function Layout({ children }) {
+  const setAppTheme = () => {
+    const darkMode =
+      window.matchMedia("(prefers-color-scheme: dark)").matches ||
+      localStorage.getItem("theme") === "dark";
+
+    const lightMode =
+      window.matchMedia("(prefers-color-scheme: light)").matches ||
+      localStorage.getItem("theme") === "light";
+
+    if (darkMode) {
+      document.documentElement.classList.add("dark");
+    } else if (lightMode) {
+      document.documentElement.classList.remove("dark");
+    }
+    return;
+  };
+
+  const handleSystemThemeChange = () => {
+    var darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    darkQuery.onchange = (e) => {
+      if (e.matches) {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+    };
+  };
+
+  useEffect(() => {
+    setAppTheme();
+  }, []);
+
+  useEffect(() => {
+    handleSystemThemeChange();
+  }, []);
+
   return (
     <div className="relative pb-24">
       <div className="flex flex-col items-center max-w-2xl w-full mx-auto">

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -16,13 +16,8 @@ export function GradientBackground({ variant, className }) {
 
 export default function Layout({ children }) {
   const setAppTheme = () => {
-    const darkMode =
-      window.matchMedia("(prefers-color-scheme: dark)").matches ||
-      localStorage.getItem("theme") === "dark";
-
-    const lightMode =
-      window.matchMedia("(prefers-color-scheme: light)").matches ||
-      localStorage.getItem("theme") === "light";
+    const darkMode = localStorage.getItem("theme") === "dark";
+    const lightMode = localStorage.getItem("theme") === "light";
 
     if (darkMode) {
       document.documentElement.classList.add("dark");
@@ -38,8 +33,10 @@ export default function Layout({ children }) {
     darkQuery.onchange = (e) => {
       if (e.matches) {
         document.documentElement.classList.add("dark");
+        localStorage.setItem("theme", "dark");
       } else {
         document.documentElement.classList.remove("dark");
+        localStorage.setItem("theme", "light");
       }
     };
   };

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import styles from "./Layout.module.css";
 
 export function GradientBackground({ variant, className }) {
@@ -13,8 +13,6 @@ export function GradientBackground({ variant, className }) {
 
   return <div className={classes} />;
 }
-
-export const ThemeContext = React.createContext("light");
 
 export default function Layout({ children }) {
   const setAppTheme = () => {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,44 +9,6 @@ class MyDocument extends Document {
         <body
           className={`antialiased text-lg bg-white dark:bg-gray-900 dark:text-white leading-base`}
         >
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-                (function () {
-                  function setTheme(newTheme) {
-                    window.__theme = newTheme;
-                    if (newTheme === 'dark') {
-                      document.documentElement.classList.add('dark');
-                    } else if (newTheme === 'light') {
-                      document.documentElement.classList.remove('dark');
-                    }
-                  }
-                  var preferredTheme;
-                  try {
-                    preferredTheme = localStorage.getItem('theme');
-                  } catch (err) { }
-                  window.__setPreferredTheme = function(newTheme) {
-                    preferredTheme = newTheme;
-                    setTheme(newTheme);
-                    try {
-                      localStorage.setItem('theme', newTheme);
-                    } catch (err) { }
-                  };
-                  var initialTheme = preferredTheme;
-                  var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
-                  if (!initialTheme) {
-                    initialTheme = darkQuery.matches ? 'dark' : 'light';
-                  }
-                  setTheme(initialTheme);
-                  darkQuery.addListener(function (e) {
-                    if (!preferredTheme) {
-                      setTheme(e.matches ? 'dark' : 'light');
-                    }
-                  });
-                })();
-              `,
-            }}
-          />
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
This PR moves the code from the `__document.js` file to the `Layout` component.

## Test plan

- [ ] When running the app the first time, the default theme should be the system one.
- [ ] When toggling themes in the footer, the correct theme should be rendered.
- [ ] On refresh, the last theme chosen should be persisted.
- [ ] When changing system theme, the app should be updated.