### PR TITLE
Add build command in .toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
 [[plugins]]
-package = "@netlify/plugin-nextjs"
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary

This PR adds a build command and publish directory in the .toml file to fix the issue with the deploys failing when using the CLI command.