### PR TITLE
fix: Updates heading levels for blog index

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -33,7 +33,7 @@ export default function Index({ posts, globalData }) {
                       {post.data.date}
                     </p>
                   )}
-                  <h3 className="text-2xl md:text-3xl">{post.data.title}</h3>
+                  <h2 className="text-2xl md:text-3xl">{post.data.title}</h2>
                   {post.data.description && (
                     <p className="mt-3 text-lg opacity-60">
                       {post.data.description}


### PR DESCRIPTION
## Summary

To make sure that our experience can have the correct announcements and expectations for users, we updated the heading order to move from `h1 -> h3` to `h1 -> h2`.

Using Tailwind's CSS classnames, nothing will be changed as far as the visually rendered output but the semantics are more precise.

Fixes #21