### PR TITLE
Fix overflow-x on mobile

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -50,7 +50,7 @@ export default function Layout({ children }) {
   }, []);
 
   return (
-    <div className="relative pb-24 overflow-x-hidden">
+    <div className="relative pb-24 overflow-hidden">
       <div className="flex flex-col items-center max-w-2xl w-full mx-auto">
         {children}
       </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -50,7 +50,7 @@ export default function Layout({ children }) {
   }, []);
 
   return (
-    <div className="relative pb-24">
+    <div className="relative pb-24 overflow-x-hidden">
       <div className="flex flex-col items-center max-w-2xl w-full mx-auto">
         {children}
       </div>


### PR DESCRIPTION
On mobile the rotated gradient component move the main container to the left